### PR TITLE
Fix ClickHouse version check

### DIFF
--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from packaging import version
@@ -47,11 +48,10 @@ def check_clickhouse_connections() -> None:
 
 def check_clickhouse(clickhouse: ClickhousePool) -> None:
     ver = clickhouse.execute("SELECT version()").results[0][0]
-    # The newer versions of altinity on arm add this to the version
-    # and it breaks this check
-    ver = ver.replace(".testingarm", "")
-    ver = ver.replace(".altinitystable", "")
-    if version.parse(ver) < version.parse(CLICKHOUSE_SERVER_MIN_VERSION):
+    ver = re.search("(\d+.\d+.\d+.\d+)", ver)
+    if ver is None or version.parse(ver.group()) < version.parse(
+        CLICKHOUSE_SERVER_MIN_VERSION
+    ):
         raise InvalidClickhouseVersion(
-            f"Snuba requires Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION} ({clickhouse.host}:{clickhouse.port} - {ver})"
+            f"Snuba requires minimum Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION} ({clickhouse.host}:{clickhouse.port} - {ver})"
         )


### PR DESCRIPTION
Use regex to extract the ClickHouse version.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
